### PR TITLE
Github ActionsでAssigneeの自動設定を行う

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,21 @@
+name: Set Assignee
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  assign:
+    name: Assign
+    if: endsWith(github.actor, '[bot]') == false && github.event.pull_request.assignee == null
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      repository-projects: read
+    steps:
+      - name: Add event actor to assignees
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr edit ${{ github.event.number }} --add-assignee ${{ github.actor }}


### PR DESCRIPTION
## 概要
PR作成時に自動でAssigneesの設定を行う