### PR TITLE
assume roleで認証できるようにする

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -43,11 +43,11 @@ jobs:
       #   run: |
       #     sudo apt install fonts-ipafont fonts-ipaexfont
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials(OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-1
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Configure AWS credentials(OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          # role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::532127140133:role/RegSuitS3ActionsAccess
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install Playwright Browsers

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -12,8 +12,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
+  id-token: write
   contents: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -44,10 +44,9 @@ jobs:
       #     sudo apt install fonts-ipafont fonts-ipaexfont
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       - name: Install Playwright Browsers

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Configure AWS credentials(OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          role-to-assume: arn:aws:iam::532127140133:role/RegSuitS3ActionsAccess
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install Playwright Browsers

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "lint": "eslint --fix src/**/*.{ts,vue}",
     "vrt": "reg-suit run",
     "vrt:local": "reg-suit run -c regconfig.local.json",
+    "snapshot:local": "rm -rf tests/directory_contains_actual_images && playwright test tests/snapshot.spec.ts",
     "snapshot": "playwright test tests/snapshot.spec.ts",
     "e2e:all": "playwright test",
-    "e2e:chromium": "rm -rf directory_contains_actual_images && playwright test --project=chromium"
+    "e2e:chromium": "rm -rf tests/directory_contains_actual_images && playwright test --project=chromium"
   },
   "dependencies": {
     "vue": "^3.4.29",

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import "./style.css";
-import { createMemoryHistory, createRouter } from "vue-router";
+import { createWebHistory, createRouter } from "vue-router";
 import App from "./App.vue";
 import Home from "./pages/Home.vue";
 import About from "./pages/About.vue";
@@ -11,7 +11,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createMemoryHistory(),
+  history: createWebHistory(),
   routes,
 });
 


### PR DESCRIPTION
## 概要
- `.github/workflows/vrt.yml` にて、AWS認証方式をOIDC（OpenID Connect）に変更し、`aws-actions/configure-aws-credentials`のバージョンをv1→v4へアップデートしました。
- `role-to-assume`や`aws-region`など、よりセキュアな認証方法に変更しています。
- 権限設定や一部不要な権限の削除も実施しています。
- `package.json` では `snapshot:local` スクリプトの追加や、`e2e:chromium` スクリプトのディレクトリパス修正を行いました。
- `src/main.js` ではルーターの履歴管理を `createMemoryHistory` から `createWebHistory` に変更しました。

## 検証項目
- [ ] GitHub Actions のワークフローが正常に動作し、OIDC認証でAWSリソースにアクセスできること
- [ ] 追加・修正したnpmスクリプト（`snapshot:local`, `e2e:chromium`）が正常に動作すること
- [ ] ルーティングの履歴管理が `createWebHistory` で正しく動作し、リロード時も期待通りの挙動となること

---

ご確認よろしくお願いします。